### PR TITLE
Update gitgo properties

### DIFF
--- a/.gitgo
+++ b/.gitgo
@@ -1,1 +1,30 @@
-{"current_issue":{"number":"8","labels":["enhancement","test label"],"title":"Add a feature to suggest commit messages"},"commit_guidelines":["fix:","feat:","docs:"],"emojis":{"initial_commit":"tada","feature":"sparkles","ui":"art","code_quality":"package","performance":"racehorse","security":"lock","config":"wrench","accessibility":"wheelchair","dev_tools":"rocket","docs":"pencil","release":"gem","bug_fix":"bug","crash":"boom","cleanup":"fire","wip":"construction"},"current_branch":{},"current_emoji":{}}
+{
+	"current_issue": {
+		"number": "8",
+		"labels": ["enhancement", "test label"],
+		"title": "Add a feature to suggest commit messages"
+	},
+	"commit_guidelines": ["fix:", "feat:", "docs:"],
+	"custom_guidelines": false,
+	"selected_commit_type": "",
+	"emojis": {
+		"initial_commit": "tada",
+		"feature": "sparkles",
+		"ui": "art",
+		"code_quality": "package",
+		"performance": "racehorse",
+		"security": "lock",
+		"config": "wrench",
+		"accessibility": "wheelchair",
+		"dev_tools": "rocket",
+		"docs": "pencil",
+		"release": "gem",
+		"bug_fix": "bug",
+		"crash": "boom",
+		"cleanup": "fire",
+		"wip": "construction"
+	},
+	"current_branch": "",
+	"current_emoji": "",
+	"current_commit_message": ""
+}


### PR DESCRIPTION
The following properties have been added to the `gitgo` file: 

- `custom_guidelines`: To know whether a user has entered their set of custom guidelines or not. This is a boolean variable. 
- `selected_commit_type`: Use this to store the  issue/commit type user selects on running `gg start`
- `current_commit_message`: A property to store the final commit message that will be suggested to the user and used during the commit action