### PR TITLE
Write the commit type to gitgo

### DIFF
--- a/lib/inquirer.js
+++ b/lib/inquirer.js
@@ -39,6 +39,16 @@ module.exports = {
                     ]
                 }]).then(
                     ans => {
+                        jsonReader('./.gitgo', (err, conf) => {
+                            if (err) {
+                                console.log('Error reading file:', err)
+                                return
+                            }
+                            conf.selected_commit_type = ans['issueType'];
+                            fs.writeFile('./.gitgo', JSON.stringify(conf), (err) => {
+                                if (err) console.log('Error writing file:', err)
+                            })
+                        });
                         // passes issue number to the function which fetches the issue title
                         getIssue(_issueNumber)
                     }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "a magnificent tool to auto-suggest everything you need before pushing a git commit.",
   "bin": {
-    "gg": "./bin/index.js"
+    "gtg": "./bin/index.js"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
fixes #27 

Changes made: 
 - write the commit type to gitgo
- change the cli to `gtg` instead of `gg`