### PR TITLE
cli: fixed .gitgo line change after writeFile() execution

### DIFF
--- a/.gitgo
+++ b/.gitgo
@@ -1,30 +1,37 @@
 {
-	"current_issue": {
-		"number": "8",
-		"labels": ["enhancement", "test label"],
-		"title": "Add a feature to suggest commit messages"
-	},
-	"commit_guidelines": ["fix:", "feat:", "docs:"],
-	"custom_guidelines": false,
-	"selected_commit_type": "",
-	"emojis": {
-		"initial_commit": "tada",
-		"feature": "sparkles",
-		"ui": "art",
-		"code_quality": "package",
-		"performance": "racehorse",
-		"security": "lock",
-		"config": "wrench",
-		"accessibility": "wheelchair",
-		"dev_tools": "rocket",
-		"docs": "pencil",
-		"release": "gem",
-		"bug_fix": "bug",
-		"crash": "boom",
-		"cleanup": "fire",
-		"wip": "construction"
-	},
-	"current_branch": "",
-	"current_emoji": "",
-	"current_commit_message": ""
+  "current_issue": {
+    "number": "8",
+    "labels": [
+      "enhancement",
+      "test label"
+    ],
+    "title": "Add a feature to suggest commit messages"
+  },
+  "commit_guidelines": [
+    "fix:",
+    "feat:",
+    "docs:"
+  ],
+  "custom_guidelines": false,
+  "selected_commit_type": "🎉 Initial commit",
+  "emojis": {
+    "initial_commit": "tada",
+    "feature": "sparkles",
+    "ui": "art",
+    "code_quality": "package",
+    "performance": "racehorse",
+    "security": "lock",
+    "config": "wrench",
+    "accessibility": "wheelchair",
+    "dev_tools": "rocket",
+    "docs": "pencil",
+    "release": "gem",
+    "bug_fix": "bug",
+    "crash": "boom",
+    "cleanup": "fire",
+    "wip": "construction"
+  },
+  "current_branch": "",
+  "current_emoji": "",
+  "current_commit_message": ""
 }

--- a/lib/inquirer.js
+++ b/lib/inquirer.js
@@ -45,7 +45,7 @@ module.exports = {
                                 return
                             }
                             conf.selected_commit_type = ans['issueType'];
-                            fs.writeFile('./.gitgo', JSON.stringify(conf), (err) => {
+                            fs.writeFile('./.gitgo', JSON.stringify(conf, null, 2), (err) => {
                                 if (err) console.log('Error writing file:', err)
                             })
                         });
@@ -91,7 +91,7 @@ module.exports = {
                                     return
                                 }
                                 conf.commit_guidelines = ans1['commit'].split(',');
-                                fs.writeFile('./.gitgo', JSON.stringify(conf), (err) => {
+                                fs.writeFile('./.gitgo', JSON.stringify(conf, null, 2), (err) => {
                                     if (err) console.log('Error writing file:', err)
                                 })
                             })
@@ -114,7 +114,7 @@ module.exports = {
                                             return
                                         }
                                         conf.use_emojis = emo;
-                                        fs.writeFile('./.gitgo', JSON.stringify(conf), (err) => {
+                                        fs.writeFile('./.gitgo', JSON.stringify(conf, null, 2), (err) => {
                                             if (err) console.log('Error writing file:', err)
                                         })
                                     })
@@ -130,7 +130,7 @@ module.exports = {
                             return
                         }
                         conf.commit_guidelines = ans['guidelines'].split(',');
-                        fs.writeFile('./.gitgo', JSON.stringify(conf), (err) => {
+                        fs.writeFile('./.gitgo', JSON.stringify(conf, null, 2), (err) => {
                             if (err) console.log('Error writing file:', err)
                         })
                     })
@@ -153,7 +153,7 @@ module.exports = {
                                     return
                                 }
                                 conf.use_emojis = emo;
-                                fs.writeFile('./.gitgo', JSON.stringify(conf), (err) => {
+                                fs.writeFile('./.gitgo', JSON.stringify(conf, null, 2), (err) => {
                                     if (err) console.log('Error writing file:', err)
                                 })
                             })

--- a/lib/issue.js
+++ b/lib/issue.js
@@ -37,7 +37,7 @@ module.exports = {
                                     conf.current_issue.title = titleOfIssue;
                                     conf.current_issue.labels = labelsOfIssue;
                                     conf.current_issue.number = finalIssueNumber;
-                                    fs.writeFile('./.gitgo', JSON.stringify(conf), (err) => {
+                                    fs.writeFile('./.gitgo', JSON.stringify(conf, null, 2), (err) => {
                                         if (err) console.log('Error writing file:', err)
                                     })
                                 })


### PR DESCRIPTION
## Issue Fix
Fixes #29 

## Description
`.gitgo` won't collapse after running the writeFile() function because now it is converting the data to a multiline string.