### PR TITLE
Empty specific attributes from .gitgo before pushing it on github

### DIFF
--- a/.gitgo
+++ b/.gitgo
@@ -1,18 +1,18 @@
 {
   "current_issue": {
-    "number": "51",
+    "number": "53",
     "labels": [
       "cli",
-      "command",
       "enhancement"
     ],
-    "title": "Add a command to give summary of all instructions"
+    "title": "Empty specific attributes from .gitgo before pushing it on github"
   },
   "commit_guidelines": [
-    "cli:"
+    "cli:",
+    "general:"
   ],
   "custom_guidelines": true,
-  "selected_commit_type": "✨ Adding a new user-facing feature",
+  "selected_commit_type": "🚀 Improving dev tools",
   "emojis": {
     "initial_commit": "tada",
     "feature": "sparkles",
@@ -31,11 +31,13 @@
     "wip": "construction"
   },
   "existing_branches": [
+    "command-summary-instructions",
     "main"
   ],
   "current_branch": [
-    "command-summary-instructions"
+    "Empty-attributes-github"
   ],
-  "current_commit_message": "✨ cli: Add a command to give summary of all instructions",
-  "use_emojis": true
+  "current_commit_message": "🚀 cli: Empty specific attributes from .gitgo before pushing it on github",
+  "use_emojis": true,
+  "commit_config": false
 }

--- a/bin/index.js
+++ b/bin/index.js
@@ -162,22 +162,18 @@ program
           conf.current_issue.number = "";
           conf.current_issue.labels = [""];
           conf.current_issue.title = "";
-          fs.writeFile(
-            "./.gitgo",
-            JSON.stringify(conf, null, 2),
-            (err) => {
-              if (err) console.log("Error writing file:", err);
-            }
-          );
+          fs.writeFile("./.gitgo", JSON.stringify(conf, null, 2), (err) => {
+            if (err) console.log("Error writing file:", err);
+          });
           setTimeout(function () {
             exec("git add ./.gitgo", (error, stdout, stderr) => {
               if (error) {
-                  console.log(`error: ${error.message}`);
-                  return;
+                console.log(`error: ${error.message}`);
+                return;
               }
               if (stderr) {
-                  console.log(`stderr: ${stderr}`);
-                  return;
+                console.log(`stderr: ${stderr}`);
+                return;
               }
             });
             git.commit(cMsg);
@@ -186,12 +182,12 @@ program
         } else {
           exec("git reset -- ./.gitgo", (error, stdout, stderr) => {
             if (error) {
-                console.log(`error: ${error.message}`);
-                return;
+              console.log(`error: ${error.message}`);
+              return;
             }
             if (stderr) {
-                console.log(`stderr: ${stderr}`);
-                return;
+              console.log(`stderr: ${stderr}`);
+              return;
             }
           });
           git.commit(cMsg);

--- a/lib/inquirer.js
+++ b/lib/inquirer.js
@@ -120,6 +120,7 @@ module.exports = {
                       return;
                     }
                     conf.use_emojis = emo;
+                    conf.commit_config = true;
                     fs.writeFile(
                       "./.gitgo",
                       JSON.stringify(conf, null, 2),
@@ -170,6 +171,7 @@ module.exports = {
                   return;
                 }
                 conf.use_emojis = emo;
+                conf.commit_config = true;
                 fs.writeFile(
                   "./.gitgo",
                   JSON.stringify(conf, null, 2),


### PR DESCRIPTION
Fixes #53 

Empty attributes from gitgo before pushing the changes to GitHub.
Also, prevent the gitgo from being pushed every time a commit is being made. 

Changes to gitgo will be pushed only if a user did `gtg config` while working on an issue since changes in config should be pushed. 